### PR TITLE
gitignore: ignore config.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/config.php


### PR DESCRIPTION
Prevent configuration secrets from accidentally being released to the
public.
