### PR TITLE
Don't expose debug at the router level

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -2,7 +2,10 @@
 use Icebreath\API\Route;
 
 Route::add_route('/', "BaseController");
-Route::add_route('/debug', "DebugController");
 Route::add_restful_route('/shoutcast', 'shoutcast');
 Route::add_restful_route('/icecast', 'icecast');
 Route::add_restful_route('/shoutirc', 'shoutirc');
+
+if(ICEBREATH_DEBUG) {
+	Route::add_route('/debug', "DebugController");
+}


### PR DESCRIPTION
Moves the check for debug code to the point where the routes table is being built. This allows the router to intelligently choose when to add debug code or not.
